### PR TITLE
Change method for fetching commits #patch

### DIFF
--- a/.github/actions/next-tag/next-tag.py
+++ b/.github/actions/next-tag/next-tag.py
@@ -77,7 +77,7 @@ def run(
     is_prerelease = st.str_to_bool(prerelease)
     with_v:bool = st.str_to_bool(with_v)
     # find the major, minor, pathc bump counters from the commits
-    major, minor, patch = ghm.GitHelper.find_bumps_from_commits(commits, default_bump)
+    major, minor, patch = ghm.find_bumps_from_commits(commits, default_bump)
 
     new_tag = sv.next_tag(
         major_bump=major,

--- a/.github/workflows/_python_library_tests.yml
+++ b/.github/workflows/_python_library_tests.yml
@@ -49,6 +49,6 @@ jobs:
           RUN_AS_TEST: "true"
         run: |
           cd ./app/python
-          git config --local user.name "pytest"
-          git config --local user.email "dummy@dummymail.com"
+          git config --global user.name "pytest"
+          git config --global user.email "dummy@dummymail.com"
           pytest

--- a/.github/workflows/_python_library_tests.yml
+++ b/.github/workflows/_python_library_tests.yml
@@ -49,4 +49,6 @@ jobs:
           RUN_AS_TEST: "true"
         run: |
           cd ./app/python
+          git config --local user.name "pytest"
+          git config --local user.email "dummy@dummymail.com"
           pytest

--- a/app/python/test_githelper.py
+++ b/app/python/test_githelper.py
@@ -91,6 +91,10 @@ def setup_repo_with_commits(request) -> tuple:
     url = "https://github.com/ministryofjustice/opg-github-actions.git"
     repo = Repo.clone_from(url, repo_root)
 
+    # setup config info
+    repo.config_writer().set_value("user", "name", "pytest")
+    repo.config_writer().set_value("user", "email", "dummy@dummymail.com")
+
     # create new branch from head of `main`
     repo.git.checkout('main', '--')
     branch_name = 'pytest-githelper-commits'

--- a/app/python/test_githelper.py
+++ b/app/python/test_githelper.py
@@ -91,10 +91,6 @@ def setup_repo_with_commits(request) -> tuple:
     url = "https://github.com/ministryofjustice/opg-github-actions.git"
     repo = Repo.clone_from(url, repo_root)
 
-    # setup config info
-    repo.config_writer().set_value("user", "name", "pytest")
-    repo.config_writer().set_value("user", "email", "dummy@dummymail.com")
-
     # create new branch from head of `main`
     repo.git.checkout('main', '--')
     branch_name = 'pytest-githelper-commits'


### PR DESCRIPTION
- Found a built in iteration method that works with range - so no need to try and wrap in xml
- Add fixture and test to check commits with special characters are parsed correctly
- Move a class method to more accurate function (it doesnt need the repo data)
