### PR TITLE
Exclude certain packages

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -17,6 +17,10 @@
           "minor",
           "patch"
         ],
+        "excludePackageNames": [
+          "ministryofjustice/opg-github-actions",
+          "ministryofjustice/opg-github-workflows"
+        ],
         "stabilityDays": 5,
         "addLabels": ["minor-and-patch"]
       },
@@ -25,6 +29,10 @@
         "matchPackagePatterns": ["*"],
         "matchUpdateTypes": [
           "major"
+        ],
+        "excludePackageNames": [
+          "ministryofjustice/opg-github-actions",
+          "ministryofjustice/opg-github-workflows"
         ],
         "stabilityDays": 5,
         "addLabels": ["major"]


### PR DESCRIPTION
Exclude self and the workflows package to avoid a circular dependency as `opg-github-workflows` uses this repo and this repo uses `opg-github-workflows` 

#patch