### PR TITLE
ignore rather than exclude

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -17,10 +17,6 @@
           "minor",
           "patch"
         ],
-        "excludePackageNames": [
-          "ministryofjustice/opg-github-actions",
-          "ministryofjustice/opg-github-workflows"
-        ],
         "stabilityDays": 5,
         "addLabels": ["minor-and-patch"]
       },
@@ -30,13 +26,12 @@
         "matchUpdateTypes": [
           "major"
         ],
-        "excludePackageNames": [
-          "ministryofjustice/opg-github-actions",
-          "ministryofjustice/opg-github-workflows"
-        ],
         "stabilityDays": 5,
         "addLabels": ["major"]
       }
-
+    ],
+    "ignoreDeps": [
+      "ministryofjustice/opg-github-actions",
+      "ministryofjustice/opg-github-workflows"
     ]
   }


### PR DESCRIPTION
Excluding in the packageRules means they still trigger, but fall back to the default grouping, ignore should stop them being generated #patch

