### PR TITLE
Add logic and test to handle prerelease flag inaccuracy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,4 +80,5 @@ test_release_download_binary:
 	@mkdir -p $(PWD)/test-release-download-bin/tmp
 	@mkdir -p $(PWD)/test-release-download-bin/opg-gha
 	@mkdir -p $(PWD)/test-release-download-bin/opg-gha-build
-	@cd $(PWD)/.github/actions/; env DEBUG="1" hostBuild="linux_x86_64" GH_WORKSPACE="$(PWD)/test-release-download-bin/tmp" GH_ACTION_REPOSITORY="ministryofjustice/opg-github-actions" GH_ACTION_REF="v2.8.0-goversion.0" SELF="true" ./release-download.sh
+	@cd $(PWD)/.github/actions/; env DEBUG="1" hostBuild="linux_x86_64" GH_WORKSPACE="$(PWD)/test-release-download-bin/tmp" GH_ACTION_REPOSITORY="ministryofjustice/opg-github-actions" GH_ACTION_REF="v3.0.1-releasenotem.1" SELF="true" ./release-download.sh
+	@cd $(PWD)/.github/actions/; env DEBUG="1" hostBuild="linux_x86_64" GH_WORKSPACE="$(PWD)/test-release-download-bin/tmp" GH_ACTION_REPOSITORY="ministryofjustice/opg-github-actions" GH_ACTION_REF="v3.0.2" SELF="true" ./release-download.sh

--- a/go/cmd/latesttag/latesttag_test.go
+++ b/go/cmd/latesttag/latesttag_test.go
@@ -82,7 +82,7 @@ func TestLatestTag(t *testing.T) {
 		},
 	}
 	for _, f := range fixtures {
-		actual, e := process(f.Tags, f.Prerelease, "beta", "beta")
+		actual, e := process(f.Tags, f.Prerelease, "beta", "beta", "master,main")
 		if e != nil {
 			t.Errorf("unexpected error")
 			t.Error(e)

--- a/go/cmd/latesttag/run.go
+++ b/go/cmd/latesttag/run.go
@@ -7,11 +7,13 @@ import (
 	"opg-github-actions/pkg/gitsemver"
 	"opg-github-actions/pkg/safestrings"
 	"opg-github-actions/pkg/semver"
+	"slices"
+	"strings"
 
 	"github.com/go-git/go-git/v5/plumbing"
 )
 
-func process(allTags []*plumbing.Reference, prerelease bool, prereleaseSuffix string, branch string) (output map[string]string, err error) {
+func process(allTags []*plumbing.Reference, prerelease bool, prereleaseSuffix string, branch string, releaseBranches string) (output map[string]string, err error) {
 	var (
 		releases              = []*plumbing.Reference{}
 		prereleases           = []*plumbing.Reference{}
@@ -20,6 +22,13 @@ func process(allTags []*plumbing.Reference, prerelease bool, prereleaseSuffix st
 		lastRelease    string = ""
 	)
 	output = map[string]string{}
+	// Check if the branch is actually a release branch, is so
+	// overwrite the prerelease flag to be false
+	releaseBranchList := strings.Split(releaseBranches, ",")
+	branchIsRelease := slices.Contains(releaseBranchList, branch)
+	if branchIsRelease {
+		prerelease = false
+	}
 
 	// get all releases
 	releases = gitsemver.Releases(allTags)
@@ -52,7 +61,7 @@ func process(allTags []*plumbing.Reference, prerelease bool, prereleaseSuffix st
 	output["all_prereleases"] = tags.Join(allPrereleases)
 	output["relevent_prereleases"] = tags.Join(prereleases)
 	output["with_v"] = fmt.Sprintf("%t", hasPrefix)
-
+	output["prerelease"] = fmt.Sprintf("%t", prerelease)
 	output["last_release"] = lastRelease
 	output["last_prerelease"] = lastPre
 	return
@@ -82,14 +91,14 @@ func Run(args []string) (output map[string]string, err error) {
 	if err != nil {
 		return
 	}
-	output, err = process(tags, isPre, *prereleaseSuffix, *branchName)
+	output, err = process(tags, isPre, *prereleaseSuffix, *branchName, *releaseBranches)
 	if err != nil {
 		return
 	}
 
+	output["original_prerelease"] = fmt.Sprintf("%t", isPre)
 	output["directory"] = *repositoryDir
 	output["branch_name"] = *branchName
-	output["prerelease"] = fmt.Sprintf("%t", isPre)
 	output["prerelease_suffix"] = *prereleaseSuffix
 
 	return

--- a/go/main_test.go
+++ b/go/main_test.go
@@ -359,6 +359,57 @@ var (
 				Expected: map[string]string{"created_tag": "v2.0.0", "regenerated": "false"},
 			},
 		},
+
+		// Test a release that has prerelease set to true, should still generate a non-prerelease value
+		// => v2.0.0
+		{
+			Prerelease: true,
+			EventSetup: eventSetup{
+				Event: "push",
+			},
+			RepoSetup: repoSetup{
+				Btc: []branchCommitTags{
+					{
+						Branch: "alpha",
+						TagCom: []tagCommit{
+							{Msg: "commit", Tag: "v0.0.2-beta.0"},
+							{Msg: "this commit should not be used #patch"},
+						},
+					},
+					{
+						Capture: true,
+						Branch:  "master",
+						TagCom: []tagCommit{
+							{Msg: "release", Tag: "v1.10.0"},
+							{Msg: "commit test", Tag: "v1.9.0"},
+							{Msg: "commit #minor"},
+						},
+					},
+					{
+						Branch: "beta",
+						TagCom: []tagCommit{
+							{Msg: "commit", Tag: "v2.0.0-beta.0"},
+							{Msg: "this commit should not be used either #major"},
+						},
+					},
+				},
+			},
+			// branch name test setup
+			BranchTest: branchFixture{
+				Event:    "push",
+				Expected: map[string]string{"full_length": "master", "safe": "master", "branch_name": "master"},
+			},
+			LatestTagTest: latestTagFixture{
+				Expected: map[string]string{"last_release": "v1.10.0"},
+			},
+			NextTagTest: nextTagFixture{
+				ExtraMessage: "#major messsage",
+				Expected:     map[string]string{"next_tag": "v2.0.0", "last_release": "v1.10.0", "last_prerelease": ""},
+			},
+			CreateTagTest: createTagFixture{
+				Expected: map[string]string{"created_tag": "v2.0.0", "regenerated": "false"},
+			},
+		},
 	}
 )
 


### PR DESCRIPTION
If prerelease is true, but the branch is a release branch then force prerelease to be false.

In org-infra, found that the prerelease is always being passed as true, so this will fix it from this side and ensure it will become false on a release branch (main).

Have a pr in org-infra to debug the cause of it always being true once this is merged