### PR TITLE
add clean up step to remove created resources

### DIFF
--- a/.github/actions/create-tag/action.yml
+++ b/.github/actions/create-tag/action.yml
@@ -128,3 +128,19 @@ runs:
       run: |
         echo -e "Running create-tag"
         ${APP_BIN} create-tag --repository="${repository}" --tag-name="${tagName}" --commitish="${commitish}" --regen="${regen}" --push="${push}"
+    ######
+    # clean up directories and other resources created
+    - name: "Clean up"
+      if: ${{ always() }}
+      shell: bash
+      env:
+        app_binary: '${{ steps.binary.outputs.binary }}'
+        target_dir: '${{ github.workspace}}/_target'
+        DEBUG: ${{ runner.debug }}
+      run: |
+        echo -e "Clean up created resources"        
+        rm -Rf "${{ env.app_binary }}"
+        rm -Rf "${{ env.target_dir }}"
+        if [ "${{ env.DEBUG }}" == "1" ]; then
+          git status
+        fi

--- a/.github/actions/next-tag/action.yml
+++ b/.github/actions/next-tag/action.yml
@@ -151,4 +151,19 @@ runs:
         echo -e "Running next-tag"
 
         ${APP_BIN} next-tag --repository="${repository}" --base="${base}" --head="${head}" --last-release="${lastRelease}" --last-prerelease="${lastPrerelease}" --prerelease="${prerelease}" --prerelease-suffix="${prereleaseSuffix}" --with-v="${withV}" --default-bump="${defaultBump}" --extra-message="${extraMsg}"
-    
+    ######
+    # clean up directories and other resources created
+    - name: "Clean up"
+      if: ${{ always() }}
+      shell: bash
+      env:
+        app_binary: '${{ steps.binary.outputs.binary }}'
+        target_dir: '${{ github.workspace}}/_target'
+        DEBUG: ${{ runner.debug }}
+      run: |
+        echo -e "Clean up created resources"        
+        rm -Rf "${{ env.app_binary }}"
+        rm -Rf "${{ env.target_dir }}"
+        if [ "${{ env.DEBUG }}" == "1" ]; then
+          git status
+        fi 

--- a/.github/actions/safe-strings/action.yml
+++ b/.github/actions/safe-strings/action.yml
@@ -120,3 +120,17 @@ runs:
       run: |
         echo -e "Running safe-string"
         ${APP_BIN} safe-string --string="${original}" --length="${length}" --suffix="${suffix}" --conditional-match="${conditinalMatch}" --conditional-value="${conditionalValue}"
+    ######
+    # clean up directories and other resources created
+    - name: "Clean up"
+      if: ${{ always() }}
+      shell: bash
+      env:
+        app_binary: '${{ steps.binary.outputs.binary }}'
+        DEBUG: ${{ runner.debug }}
+      run: |
+        echo -e "Clean up created resources"        
+        rm -Rf "${{ env.app_binary }}"
+        if [ "${{ env.DEBUG }}" == "1" ]; then
+          git status
+        fi       

--- a/.github/actions/semver-tag/action.yml
+++ b/.github/actions/semver-tag/action.yml
@@ -287,9 +287,11 @@ runs:
       if: ${{ always() }}
       shell: bash
       env:
-        app_binary: "${{ steps.binary.outputs.binary }}"
+        app_binary: '${{ steps.binary.outputs.binary }}'
         target_dir: '${{ github.workspace}}/_target'
       run: |
         echo -e "Clean up created resources"        
+        git status
         rm -Rf "${{ env.app_binary }}"
         rm -Rf "${{ env.target_dir }}"
+        git status

--- a/.github/actions/semver-tag/action.yml
+++ b/.github/actions/semver-tag/action.yml
@@ -281,3 +281,15 @@ runs:
         if [ -n "${{ steps.create_release.outputs.id }}" ]; then
           echo "| **Release** | **URL** | **[${{ steps.create_release.outputs.id }}](${{ steps.create_release.outputs.html_url }})** |"  >> $GITHUB_STEP_SUMMARY
         fi        
+    ######
+    # clean up directories and other resources created
+    - name: "Clean up"
+      if: ${{ always() }}
+      shell: bash
+      env:
+        app_binary: "${{ steps.binary.outputs.binary }}"
+        target_dir: '${{ github.workspace}}/_target'
+      run: |
+        echo -e "Clean up created resources"        
+        rm -Rf "${{ env.app_binary }}"
+        rm -Rf "${{ env.target_dir }}"

--- a/.github/actions/semver-tag/action.yml
+++ b/.github/actions/semver-tag/action.yml
@@ -289,9 +289,11 @@ runs:
       env:
         app_binary: '${{ steps.binary.outputs.binary }}'
         target_dir: '${{ github.workspace}}/_target'
+        DEBUG: ${{ runner.debug }}
       run: |
         echo -e "Clean up created resources"        
-        git status
         rm -Rf "${{ env.app_binary }}"
         rm -Rf "${{ env.target_dir }}"
-        git status
+        if [ "${{ env.DEBUG }}" == "1" ]; then
+          git status
+        fi

--- a/.github/actions/terraform-version/action.yml
+++ b/.github/actions/terraform-version/action.yml
@@ -117,4 +117,20 @@ runs:
         echo -e "Running terraform-version"
 
         ${APP_BIN} terraform-version --directory="${Directory}" --versions-file="${VersionsFile}" --simple="${SimpleFile}"
+    ######
+    # clean up directories and other resources created
+    - name: "Clean up"
+      if: ${{ always() }}
+      shell: bash
+      env:
+        app_binary: '${{ steps.binary.outputs.binary }}'
+        target_dir: '${{ github.workspace}}/_target'
+        DEBUG: ${{ runner.debug }}
+      run: |
+        echo -e "Clean up created resources"        
+        rm -Rf "${{ env.app_binary }}"
+        rm -Rf "${{ env.target_dir }}"
+        if [ "${{ env.DEBUG }}" == "1" ]; then
+          git status
+        fi         
           


### PR DESCRIPTION
When using these actions they create a temp folder to checkout resources - this causes git status to be "dirty" and can stop other actions from working correctly.

This change is to cleanup those temp resources before exiting.