### PR TITLE
Add an action for stopwatch like functions

### DIFF
--- a/.github/actions/timer/README.md
+++ b/.github/actions/timer/README.md
@@ -1,0 +1,72 @@
+# Timer Composite Action
+
+Provides simple timer functionality so you can track how long sections of workflows take to run - for exmaple image builds or infrastructure deployments
+
+## Usage
+
+Within you github workflow job you can place this to start a timer:
+
+```yaml
+    - name: "Start build timer"
+      id: build_start
+      uses: 'ministryofjustice/opg-github-actions/.github/actions/timer@v3.0.7'
+```
+
+Then, later in your workflow you can stop that timer and get duration information by including the below style step:
+
+```yaml
+    - name: "Stop build timer"
+      id: build_stop
+      uses: 'ministryofjustice/opg-github-actions/.github/actions/timer@v3.0.7'
+      with:
+        stop: true
+        timestamp: ${{ steps.build_start.outputs.start }}
+```
+
+The `timestamp` variable passed is a IS0 8601 timestamp (UTC timezone) in the below format:
+
+```
+2024-03-26T08:47:21.029473+00:00
+```
+
+*Please note the `+00:00` usage rather than `Z` for timezone offsets.*
+
+
+## Inputs and Outputs
+
+Inputs:
+- `start` (default: "true")
+- `stop`
+- `timestamp` 
+
+Outputs:
+- **`duration`**
+- `start`
+- `end`
+- `duration_as_milliseconds`
+- `duration_as_seconds`
+- `duration_as_minutes`
+- `duration_as_hours`
+
+
+### Inputs
+
+#### `start` (default: "true")
+While this is true and `stop` has no value, then this will trigger the generation of a timestamp
+
+#### `stop` and `timestamp` 
+When `stop` is set to true and a timestamp value is passed this will trigger the output of duration information between the current time and the value of timestamp.
+
+
+### Outputs
+
+#### `duration`
+The difference in seconds between the passed timestamp and the current time. This is rounded to the nearest second, for more accuracy you can use `duration_as_milliseconds` or `duration_as_seconds`.
+
+#### `start` and `end`
+The two timestamp values used to calculate the duration data.
+
+#### `duration_as_milliseconds`, `duration_as_seconds`, `duration_as_minutes`, `duration_as_hours`
+Additional duration formats that provide deciminal versions of there respective unit of time.
+
+

--- a/.github/actions/timer/action.yml
+++ b/.github/actions/timer/action.yml
@@ -1,0 +1,119 @@
+name: "Timer"
+description: "Provide start / stop & duration information."
+
+inputs:
+  start:
+    description: "Instruct the timer to start"
+    default: "true"
+  stop:
+    description: "Instruct the timer to stop"
+    default: ""
+  timestamp:
+    description: "ISO 8601 formatted timestamp used with 'stop' to determine the duration"
+    default: ""
+  _test_end_timestamp:
+    description: "Used to overwrite the stop timestamp for testing"
+    default: ""
+
+
+outputs:
+  start:
+    description: "ISO 8601 timestmap with milliseconds to track the start time"
+    value: ${{ steps.start.outputs.start }}
+  end:
+    description: "ISO 8601 timestmap with milliseconds to track the end time"
+    value: ${{ steps.stop.outputs.stop }}
+
+  duration:
+    description: "Time (to the closest second) between the start and end timestamps."
+    value: ${{ steps.duration.outputs.as_seconds_rounded }}  
+  
+  duration_as_milliseconds:
+    description: "Time (in milliseconds with deciminals) between the start and end timestamps."
+    value: ${{ steps.duration.outputs.as_milliseconds }}
+  duration_as_seconds:
+    description: "Time (in seconds with deciminals) between the start and end timestamps."
+    value: ${{ steps.duration.outputs.as_seconds }}
+  duration_as_minutes:
+    description: "Time (in minutes with deciminals) between the start and end timestamps."
+    value: ${{ steps.duration.outputs.as_minutes }}
+  duration_as_hours:
+    description: "Time (in hours with deciminals) between the start and end timestamps."
+    value: ${{ steps.duration.outputs.as_hours }}
+
+
+runs:
+  using: "composite"
+  steps:
+    - name: "Start"
+      id: "start"
+      shell: python
+      if: ${{ inputs.stop == '' && inputs.start == 'true'}}
+      run: |
+        import os
+        from datetime import datetime, timezone        
+        iso8601 = datetime.now(timezone.utc).isoformat()
+        print(f'start={iso8601}')
+
+        if "GITHUB_OUTPUT" in os.environ:
+          with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
+            print(f'start={iso8601}', file=fh)
+    
+    - name: "Stop"
+      id: "stop"
+      shell: python
+      if: ${{ inputs.stop == 'true' && inputs.timestamp != ''}}      
+      run: |
+        import os
+        from datetime import datetime, timezone
+        iso8601 = datetime.now(timezone.utc).isoformat()
+        print(f'stop={iso8601}')
+
+        if "GITHUB_OUTPUT" in os.environ:
+          with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
+            print(f'stop={iso8601}', file=fh)
+    
+    - name: "Duration"
+      id: "duration"
+      shell: python
+      if: ${{ inputs.stop == 'true' && inputs.timestamp != ''}}
+      env:
+        test_stop: ${{ inputs._test_end_timestamp }}
+        start: ${{ inputs.timestamp }}
+        # stop timestamp is either the generated version or the overwrite passed in
+        stop: ${{ inputs._test_end_timestamp != '' && inputs._test_end_timestamp || steps.stop.outputs.stop }}
+      run: |
+        import os
+        import sys
+        from datetime import datetime, timezone, timedelta
+
+        start_ts = datetime.fromisoformat(os.environ.get("start")) if "start" in os.environ else ""
+        stop_ts = datetime.fromisoformat(os.environ.get("stop")) if "stop" in os.environ else ""
+
+        if start_ts == "" or stop_ts == "":
+          print('timestamps not passed.', file=sys.stderr)
+          sys.exit()
+
+        delta = stop_ts - start_ts
+
+        milliseconds = delta / timedelta(milliseconds=1)
+        seconds = delta / timedelta(seconds=1)
+        minutes = delta / timedelta(minutes=1)
+        hours = delta / timedelta(hours=1)
+
+        print(f'as_milliseconds={milliseconds}')
+        print(f'as_seconds_rounded={round(seconds)}')
+        print(f'as_seconds={seconds}')
+        print(f'as_minutes={minutes}')
+        print(f'as_hours={hours}')
+
+        if "GITHUB_OUTPUT" in os.environ:
+          with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
+            print(f'as_milliseconds={milliseconds}')
+            print(f'as_seconds={seconds}')
+            print(f'as_seconds_rounded={round(seconds)}')
+            print(f'as_minutes={minutes}')
+            print(f'as_hours={hours}')
+
+
+      

--- a/.github/actions/timer/action.yml
+++ b/.github/actions/timer/action.yml
@@ -98,22 +98,23 @@ runs:
 
         milliseconds = delta / timedelta(milliseconds=1)
         seconds = delta / timedelta(seconds=1)
+        dur = round(seconds)
         minutes = delta / timedelta(minutes=1)
         hours = delta / timedelta(hours=1)
 
         print(f'as_milliseconds={milliseconds}')
-        print(f'as_seconds_rounded={round(seconds)}')
+        print(f'as_seconds_rounded={dur}')
         print(f'as_seconds={seconds}')
         print(f'as_minutes={minutes}')
         print(f'as_hours={hours}')
 
         if "GITHUB_OUTPUT" in os.environ:
           with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
-            print(f'as_milliseconds={milliseconds}')
-            print(f'as_seconds={seconds}')
-            print(f'as_seconds_rounded={round(seconds)}')
-            print(f'as_minutes={minutes}')
-            print(f'as_hours={hours}')
+            print(f'as_milliseconds={milliseconds}', file=fh)
+            print(f'as_seconds={seconds}', file=fh)
+            print(f'as_seconds_rounded={dur}', file=fh)
+            print(f'as_minutes={minutes}', file=fh)
+            print(f'as_hours={hours}', file=fh)
 
 
       

--- a/.github/workflows/_tests.yml
+++ b/.github/workflows/_tests.yml
@@ -18,10 +18,10 @@ jobs:
       # make sure it runs as it would in a pipeline
       - name: "timer start"
         id: "timer_start"
-        uses: './github/actions/timer.yml'
+        uses: './github/actions/timer'
       - name: "timer end"
         id: "timer_end"
-        uses: './github/actions/timer.yml'
+        uses: './github/actions/timer'
         with:
           stop: true
           timestamp: ${{ steps.timer_start.outputs.start }}          
@@ -31,7 +31,7 @@ jobs:
         env:
           ts_start: '2024-03-26T08:47:21.029473+00:00'
           ts_end: '2024-03-26T08:47:41.794944+00:00'
-        uses: './github/actions/timer.yml'
+        uses: './github/actions/timer'
         with:
           stop: true
           timestamp: ${{ env.ts_start }}

--- a/.github/workflows/_tests.yml
+++ b/.github/workflows/_tests.yml
@@ -37,14 +37,14 @@ jobs:
           timestamp: ${{ env.ts_start }}
           _test_end_timestamp: ${{ env.ts_end }}
       # check duration output from known times
-      - name: "Confirmation duration"
+      - name: "Confirm duration match"
         env:
           dur: ${{ steps.duration_test.outputs.duration }}
           expected: "21"
         shell: bash
         run: |
           echo -e "Checking duration is execpted result"
-          if [ "${{env.dur }}" != "${{ env.expected }}" ]; then
+          if [ "${{ env.dur }}" != "${{ env.expected }}" ]; then
             echo "Duration did not match"
             exit 1
           fi

--- a/.github/workflows/_tests.yml
+++ b/.github/workflows/_tests.yml
@@ -5,6 +5,50 @@ on:
   workflow_call:
 
 jobs:
+  # test timer action
+  test_timer_action:
+    name: "timer"
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+      # make sure it runs as it would in a pipeline
+      - name: "timer start"
+        id: "timer_start"
+        uses: './github/actions/timer.yml'
+      - name: "timer end"
+        id: "timer_end"
+        uses: './github/actions/timer.yml'
+        with:
+          stop: true
+          timestamp: ${{ steps.timer_start.outputs.start }}          
+      # test with known timestamps
+      - name: "known timestamps"
+        id: "duration_test"
+        env:
+          ts_start: '2024-03-26T08:47:21.029473+00:00'
+          ts_end: '2024-03-26T08:47:41.794944+00:00'
+        uses: './github/actions/timer.yml'
+        with:
+          stop: true
+          timestamp: ${{ env.ts_start }}
+          _test_end_timestamp: ${{ env.ts_end }}
+      # check duration output from known times
+      - name: "Confirmation duration"
+        env:
+          dur: ${{ steps.duration_test.outputs.duration }}
+          expected: "21"
+        shell: bash
+        run: |
+          echo -e "Checking duration is execpted result"
+          if [ "${{env.dur }}" != "${{ env.expected }}" ]; then
+            echo "Duration did not match"
+            exit 1
+          fi
+
 
   # test terraform-workspace-manager
   test_terraform_workspace_manager:

--- a/.github/workflows/_tests.yml
+++ b/.github/workflows/_tests.yml
@@ -18,10 +18,10 @@ jobs:
       # make sure it runs as it would in a pipeline
       - name: "timer start"
         id: "timer_start"
-        uses: './github/actions/timer'
+        uses: './.github/actions/timer'
       - name: "timer end"
         id: "timer_end"
-        uses: './github/actions/timer'
+        uses: './.github/actions/timer'
         with:
           stop: true
           timestamp: ${{ steps.timer_start.outputs.start }}          
@@ -31,7 +31,7 @@ jobs:
         env:
           ts_start: '2024-03-26T08:47:21.029473+00:00'
           ts_end: '2024-03-26T08:47:41.794944+00:00'
-        uses: './github/actions/timer'
+        uses: './.github/actions/timer'
         with:
           stop: true
           timestamp: ${{ env.ts_start }}

--- a/README.md
+++ b/README.md
@@ -81,6 +81,14 @@ A shared terraform workspace tool to track and list workspaces protected from de
 
 [More Details](./.github/actions/terraform-workspace-manager/README.md)
 
+
+### Timer
+
+Used to calculate duration within github actions - for example measuring how long each docker image takes to build.
+
+[More Details](./.github/actions/timer/README.md)
+
+
 ## Tests
 
 Tests can be run using commands with the `Makefile` from the root of this directory.


### PR DESCRIPTION
This action is intended to be used for tracking how long sections of the pipeline take within the workflow, so this information can then be surfaced directly (in the worfklow summary) or pushed to external metric services.