### PR TITLE
Add option length param to the branch-name action

### DIFF
--- a/.github/actions/branch-name/action.yml
+++ b/.github/actions/branch-name/action.yml
@@ -1,6 +1,11 @@
 name: "Branch Name"
 description: "Get branch data. Example: ref/heads/main-123-456-789 => main-123-456-789. Also return safe-strings versions."
 
+inputs:
+  length:
+    description: "Max length of the safe string"
+    default: "12"
+
 outputs:
   branch_name:
     description: "Branch name"
@@ -32,7 +37,7 @@ runs:
         echo -e "${err}" >&2
         echo -e "${err}" >> $GITHUB_STEP_SUMMARY
         exit 1
-    # Use bash shell script to fetch and work out releases    
+    # Use bash shell script to fetch and work out releases
     - name: "Get release binary for this runner"
       shell: bash
       id: fetch
@@ -64,7 +69,7 @@ runs:
       run: |
         echo -e "Build from source"
         cd ${buildSource}
-        echo -e "Building (with make) for ${target}"        
+        echo -e "Building (with make) for ${target}"
         make release
         release="${buildSource}/go/builds/${target}"
         echo -e "RELEASE=${release}"
@@ -92,15 +97,16 @@ runs:
         fi
         echo -e "binary=${binary}"
         echo "binary=${binary}" >> $GITHUB_OUTPUT
-    ##### <<< END REPEATING BLOCK  
+    ##### <<< END REPEATING BLOCK
     #### COMMANDS
     # RUN THE COMMAND
     - name: Generate branch info
       id: safe
       shell: bash
-      env:        
+      env:
         LOG_LEVEL: ${{ runner.debug == '1' && 'debug' || 'error' }}
         APP_BIN: "${{ steps.binary.outputs.binary }}"
+        length: "${{ inputs.length }}"
       run: |
-        echo -e "Run branch-name"        
-        ${APP_BIN} branch-name --event-name="${GITHUB_EVENT_NAME}" --event-data-file="${GITHUB_EVENT_PATH}"
+        echo -e "Run branch-name"
+        ${APP_BIN} branch-name --event-name="${GITHUB_EVENT_NAME}" --event-data-file="${GITHUB_EVENT_PATH}" --length="${{ env.length }}"

--- a/go/cmd/branchname/branchname.go
+++ b/go/cmd/branchname/branchname.go
@@ -25,11 +25,12 @@ package branchname
 import "flag"
 
 var (
-	Name          = "branch-name"                           // Command name
-	FlagSet       = flag.NewFlagSet(Name, flag.ExitOnError) // Argument group
-	Length        = 12                                      // Max length
-	eventName     = FlagSet.String("event-name", "", "Name of the event: [pull_request|push]")
-	eventDataFile = FlagSet.String("event-data-file", "", "File where event environment data is stored")
+	DefaultMaxLength int = 12
+	Name                 = "branch-name"                                                // Command name
+	FlagSet              = flag.NewFlagSet(Name, flag.ExitOnError)                      // Argument group
+	Length               = FlagSet.Int("length", DefaultMaxLength, "Max length to use") // Max length
+	eventName            = FlagSet.String("event-name", "", "Name of the event: [pull_request|push]")
+	eventDataFile        = FlagSet.String("event-data-file", "", "File where event environment data is stored")
 )
 
 var eventNameChoices = []string{"pull_request", "push"}

--- a/go/cmd/branchname/branchname_test.go
+++ b/go/cmd/branchname/branchname_test.go
@@ -8,6 +8,7 @@ import (
 // inFixture are the input arguments
 type testFixture struct {
 	Event    string
+	Length   int
 	Content  []byte
 	Error    bool
 	Expected map[string]string
@@ -18,33 +19,50 @@ func TestBranchNameCleaned(t *testing.T) {
 
 	fixtures := []testFixture{
 		{
+			Length:   DefaultMaxLength,
 			Event:    "pull_request",
 			Content:  testlib.TestEventPullRequest("main", "my-feature-branch", "title", "body"),
 			Expected: map[string]string{"full_length": "myfeaturebranch", "safe": "myfeaturebra", "branch_name": "my-feature-branch"},
 		},
 		{
+			Length:   DefaultMaxLength,
 			Event:    "pull_request",
 			Content:  testlib.TestEventPullRequest("main", "my-feature??", "title", "body"),
 			Expected: map[string]string{"full_length": "myfeature", "safe": "myfeature", "branch_name": "my-feature??"},
 		},
 		{
+			Length:   DefaultMaxLength,
 			Event:    "pull_request",
 			Content:  testlib.TestEventPullRequest("main", "long/string/with/slashes", "title", "body"),
 			Expected: map[string]string{"full_length": "longstringwithslashes", "safe": "longstringwi"},
 		},
 		{
+			Length:   DefaultMaxLength,
 			Event:    "pull_request",
 			Content:  testlib.TestEventPullRequest("main", "long/string-with-others?!.><~@#", "title", "body"),
 			Expected: map[string]string{"full_length": "longstringwithothers", "safe": "longstringwi"},
 		},
 		{
+			Length:   DefaultMaxLength,
 			Event:    "push",
 			Content:  testlib.TestEventPush("long/string-with-others?!.><~@#♥", "commit123", "commit1234"),
 			Expected: map[string]string{"full_length": "longstringwithothers", "safe": "longstringwi", "branch_name": "long/string-with-others?!.><~@#♥"},
 		},
+		{
+			Length:   6,
+			Event:    "push",
+			Content:  testlib.TestEventPush("long/string", "commit123", "commit1234"),
+			Expected: map[string]string{"full_length": "longstring", "safe": "longst", "branch_name": "long/string"},
+		},
+		{
+			Length:   14,
+			Event:    "push",
+			Content:  testlib.TestEventPush("renovate/my-feature-thingy-update", "commit123", "commit1234"),
+			Expected: map[string]string{"full_length": "renovatemyfeaturethingyupdate", "safe": "renovatemyfeat", "branch_name": "renovate/my-feature-thingy-update"},
+		},
 	}
 	for _, f := range fixtures {
-		out, e := process(f.Event, f.Content)
+		out, e := process(f.Event, f.Length, f.Content)
 
 		if e != nil {
 			t.Errorf("error: unexpected error")

--- a/go/cmd/branchname/run.go
+++ b/go/cmd/branchname/run.go
@@ -11,7 +11,7 @@ import (
 	"github.com/google/go-github/v58/github"
 )
 
-func process(eventType string, content []byte) (output map[string]string, err error) {
+func process(eventType string, length int, content []byte) (output map[string]string, err error) {
 	var (
 		branch  string                 = ""
 		headRef string                 = ""
@@ -45,7 +45,7 @@ func process(eventType string, content []byte) (output map[string]string, err er
 		"branch_name":    branch,
 		"head_commitish": headRef,
 		"base_commitish": baseRef,
-		"safe":           string(*clean.SafeAndShort(Length)),
+		"safe":           string(*clean.SafeAndShort(length)),
 		"full_length":    string(*clean.Safe()),
 	}
 
@@ -67,7 +67,12 @@ func Run(args []string) (output map[string]string, err error) {
 		return
 	}
 
-	output, err = process(*eventName, content)
+	len := DefaultMaxLength
+	if Length != nil {
+		len = *Length
+	}
+
+	output, err = process(*eventName, len, content)
 	output["event_data_file"] = *eventDataFile
 	return
 }


### PR DESCRIPTION
Allow branch-name safe strings length to be adjusted via input param to allow for more entropy for tooling like renovate

Defaults to 12, which is the current set limit

#minor
