### PR TITLE
Add terraform-version action back #minor

### DIFF
--- a/.github/workflows/workflow_test_gha.yml
+++ b/.github/workflows/workflow_test_gha.yml
@@ -76,6 +76,29 @@ jobs:
           echo "| full_length | ${{ steps.branchname.outputs.full_length }} |"  >> $GITHUB_STEP_SUMMARY
           echo "| safe | ${{ steps.branchname.outputs.safe }} |"  >> $GITHUB_STEP_SUMMARY
 
+  test_terraform_version:
+    name: "TEST Terraform Version"
+    runs-on: ubuntu-latest
+    steps:
+      # checkout self
+      - name: "Checkout"
+        id: checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+      - name: "Terraform Version"
+        id: "terraformversion"
+        uses: ./actions/terraform-version
+        with:
+          terraform_directory: ./terraform/account
+      # summary
+      - name: "Summary"
+        run: |
+          echo "| Variable | Value |" >> $GITHUB_STEP_SUMMARY
+          echo "| --- | --- |"  >> $GITHUB_STEP_SUMMARY
+          echo "| version | ${{ steps.terraformversion.outputs.version }} |"  >> $GITHUB_STEP_SUMMARY
+
   end:
     name: 'End'
     runs-on: 'ubuntu-latest'
@@ -83,6 +106,7 @@ jobs:
       - test_action_values
       - test_branch_name_from_env
       - test_branch_name_fixed
+      - test_terraform_version
     steps:
       - name: "End"
         id: end

--- a/Makefile
+++ b/Makefile
@@ -60,3 +60,5 @@ local/build:
 	@go mod tidy
 	@env CGO_ENABLED=0 \
 		go build -ldflags="-w -s" -o ${BUILD_DIR}/branch-name ./action/cmd/branch-name
+	@env CGO_ENABLED=0 \
+		go build -ldflags="-w -s" -o ${BUILD_DIR}/terraform-version ./action/cmd/terraform-version

--- a/action/cmd/branch-name/main.go
+++ b/action/cmd/branch-name/main.go
@@ -13,8 +13,6 @@ import (
 var (
 	maxLength int    = 12
 	original  string = ""
-	envKey    string = "NAME_FROM_ENVIRONMENT_VARS" // this is where we merged github env values into and can use that if no input is passed
-	envVal    string = ""
 )
 
 const ErrMissingValues string = "error: --source argument not passed."

--- a/action/cmd/terraform-version/main.go
+++ b/action/cmd/terraform-version/main.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log/slog"
+	"opg-github-actions/action/internal/logger"
+	"os"
+	"path/filepath"
+	"regexp"
+)
+
+// Errors
+const (
+	ErrFileNotFound       string = "error: file [%s] was not found."
+	ErrParsingVersionFile string = "error: failed to parse versions file via regex"
+)
+
+// fixed pattern to find values from the terraform file
+const requiredVersionPattern string = `(?m).*required_version.*=.*"(?P<version>.*)"(.*)$`
+
+// input arguments used via flag
+var (
+	directory string = ""
+	file      string = "versions.tf"
+)
+
+// FileExists checks if the file exists
+func fileExists(path string) bool {
+	info, err := os.Stat(path)
+	// if there is an error, or the filepath doesnt exist, return false
+	if err != nil || os.IsNotExist(err) {
+		return false
+	}
+	// return false for directories - its not a file
+	if info.IsDir() {
+		return false
+	}
+
+	return true
+}
+
+// VersionData expects the content of the version file and runs regex against it
+// to find the values
+//
+// Return example:
+//
+//	map[string]string{ "version": "1.1.0"}
+func versionData(content string) (data map[string]string, err error) {
+
+	data = map[string]string{}
+
+	// compare the file content to the regex
+	// 	- when matched, use the named groups to populate the output data
+	//	- when not matched, set an error
+	re := regexp.MustCompile(requiredVersionPattern)
+	match := re.FindStringSubmatch(content)
+	if len(match) > 0 {
+		for i, name := range re.SubexpNames() {
+			if name != "" {
+				data[name] = match[i]
+			}
+		}
+	} else {
+		err = fmt.Errorf(ErrParsingVersionFile)
+	}
+	return
+}
+
+// Run processes the input and returns the values
+// `result` should contain a `version` property - which we set a defauly version
+func Run(lg *slog.Logger, dir string, fp string) (result map[string]string, err error) {
+	var (
+		content []byte
+		file    string = filepath.Join(dir, fp)
+	)
+	result = map[string]string{"version": ""}
+
+	if !fileExists(file) {
+		err = fmt.Errorf(ErrFileNotFound, file)
+		return
+	}
+	// read the file
+	content, err = os.ReadFile(file)
+	if err != nil {
+		return
+	}
+	// pass into the check and return values
+	result, err = versionData(string(content))
+
+	return
+}
+
+// init does the setup of args
+func init() {
+	flag.StringVar(&directory, "directory", directory, "Directory path to operate from.")
+	flag.StringVar(&file, "file", file, "The terraform file that contains the required_version property.")
+}
+
+func main() {
+	var lg *slog.Logger = logger.New("INFO", "TEXT")
+	// process the arguments and fetch the fallback value from environment values
+	flag.Parse()
+	// run the command
+	res, err := Run(lg, directory, file)
+	if err != nil {
+		lg.Error(err.Error())
+		os.Exit(1)
+	}
+	logger.Result(lg, res)
+
+}

--- a/action/cmd/terraform-version/main_test.go
+++ b/action/cmd/terraform-version/main_test.go
@@ -1,0 +1,39 @@
+package main
+
+import "testing"
+
+type tvFixture struct {
+	Test     string
+	Expected string
+}
+
+func TestTerraformVersion(t *testing.T) {
+
+	fixtures := []tvFixture{
+		{
+			Test: `terraform {
+				required_version = "1.6.5"
+			}`,
+			Expected: "1.6.5",
+		},
+		{
+			Test:     `terraform {required_version = "1.6.0"}`,
+			Expected: "1.6.0",
+		},
+		{
+			Test:     `terraform {required_version = ">= 1.1.0"}`,
+			Expected: ">= 1.1.0",
+		},
+	}
+
+	for i, f := range fixtures {
+		out, e := versionData(f.Test)
+		if e != nil {
+			t.Errorf("error: unexpected error for test [%d]: %s", i, e.Error())
+		}
+
+		if out["version"] != f.Expected {
+			t.Errorf("error: expected [%s] actual [%s]", f.Expected, out["version"])
+		}
+	}
+}

--- a/actions/terraform-version/action.yml
+++ b/actions/terraform-version/action.yml
@@ -1,0 +1,64 @@
+name: "Terraform Version"
+description: >
+  Terraform Version is used to find the semver range from the terraform versions.tf file
+  (by default) and return its value. Used with `hashicorp/setup-terraform` to configure
+  terraform within workflows.
+
+  No processing or changes are made to this value, so it will return as set, so can and
+  will contain range notation like `>`, `~>` and so on.
+
+inputs:
+
+  terraform_directory:
+    description: "Directory where terraform will be run from. Looks for versions.tf file in this path."
+    required: true
+
+  terraform_versions_file:
+    description: "Name of file that contains the required_version config is stored. (Default `./versions.tf`)"
+    default: "./versions.tf"
+
+outputs:
+  version:
+    description: 'Discovered terraform version range. This may be an exact number (like 1.5.5) or a semver range (like >= 1.0).'
+    value: ${{ steps.cmd.outputs.version }}
+
+runs:
+  using: composite
+  steps:
+    ####### BUILD THE BINARY
+    # Setup go version to use from the mod file it the base
+    - name: "Setup go version"
+      uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+      with:
+        # relative path to where the go.mod file sites from inside the ./action/$name path
+        go-version-file: '${{ github.action_path }}/../../go.mod'
+        cache: false
+    # Build the binary
+    - name: "Build binary"
+      id: builder
+      shell: bash
+      env:
+        source: "${{ github.action_path }}/../../action/cmd/terraform-version"
+        build_directory: "${{ github.action_path }}/builds"
+        binary: "${{ github.action_path }}/builds/terraform-version"
+        # we dont use CGO for this command
+        CGO_ENABLED: 0
+      run: |
+        echo "Build binary from source ... "
+        mkdir -p ${{ env.build_directory }}
+        go build -ldflags="-w -s" -o ${{ env.binary }} ${{ env.source }}/
+    ####### END BUILD
+    ####### RUN COMMAND
+    # run the command
+    - name: "Find terraform version"
+      id: cmd
+      shell: bash
+      env:
+        binary: "${{ github.action_path }}/builds/terraform-version"
+        TF_DIRECTORY: ${{ inputs.terraform_directory }}
+        TF_FILE: ${{ inputs.terraform_versions_file }}
+      run: |
+        echo "Running terraform-version command ... "
+        ${{ env.binary }} \
+          --directory=${{ env.TF_DIRECTORY }} \
+          --file="${{ env.TF_FILE }}"

--- a/docs/architecture/decisions/0007-terraform-version-changes.md
+++ b/docs/architecture/decisions/0007-terraform-version-changes.md
@@ -1,0 +1,23 @@
+# 7. Terraform Version Action Changes
+
+Date: 2025-07-24
+
+## Status
+
+Accepted
+
+## Context
+
+Before the community migrated to using our standard `.envrc` file that handles terraform version switching as well and environment variable setup some projects made use of a `.terrform-version` file, as this was supported by `tfswtich` and could be read within pipelines easily.
+
+However, having this file as well as the value in `required_version` property in actual terraform files lead to drift and inconsistencies, so the community chose to move away from that approach and instead parse the contents of `versions.tf` file so ther was only one location for that configuration.
+
+For a while, the `terraform-version` action maintained backward compatability with the older `.terraform-version` plain text file for easier adoption.
+
+## Decision
+
+Out code has moved to use the community approach, so this version will no longer support the `.terraform-version` file.
+
+## Consequences
+
+If your pipeline relies the `.terraform-version` file, then you will need to update you setup to use `versions.tf` approach.


### PR DESCRIPTION
The new `terraform-version` action has move path to match standards to now be `./actions/terraform-version` and this instance no longer supports the `simple_file` variable.

ADR 0007 discuss why this support has been removed.