### PR TITLE
Fix to push event handling #minor

### DIFF
--- a/action/cmd/semver/main.go
+++ b/action/cmd/semver/main.go
@@ -170,6 +170,17 @@ func createAndPushTag(
 	return
 }
 
+func fileExists(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil || os.IsNotExist(err) {
+		return false
+	}
+	if info.IsDir() {
+		return false
+	}
+	return true
+}
+
 // getContentFromEventFile reads and parses the event file
 // that might be present at this path
 // Doing it this way as the event content contains special

--- a/action/cmd/semver/main.go
+++ b/action/cmd/semver/main.go
@@ -194,8 +194,14 @@ func getContentFromEventFile(lg *slog.Logger, file string) (content string) {
 		lg.Error("err with unmarshal", "err", err.Error())
 		return
 	}
-
-	// now look if its a pull request, and if so, parse as a
+	// handle push event
+	if _, ok := raw["commits"]; ok {
+		json.Unmarshal(bytes, &pushEvent)
+		for _, c := range pushEvent.Commits {
+			content += *c.Message
+		}
+	}
+	// look if its a pull request, and if so, parse as a
 	// pr and generate the content from that
 	if _, ok := raw["pull_request"]; ok {
 		json.Unmarshal(bytes, &prEvent)

--- a/action/cmd/semver/main.go
+++ b/action/cmd/semver/main.go
@@ -187,11 +187,16 @@ func fileExists(path string) bool {
 // characters that dont escape very well
 func getContentFromEventFile(lg *slog.Logger, file string) (content string) {
 	var (
-		err     error
-		bytes   []byte
-		prEvent *github.PullRequestEvent = &github.PullRequestEvent{}
-		raw     map[string]interface{}   = map[string]interface{}{}
+		err       error
+		bytes     []byte
+		prEvent   *github.PullRequestEvent = &github.PullRequestEvent{}
+		pushEvent *github.PushEvent        = &github.PushEvent{}
+		raw       map[string]interface{}   = map[string]interface{}{}
 	)
+	// ignore empty of missing files
+	if file == "" || !fileExists(file) {
+		return
+	}
 
 	content = ""
 	if bytes, err = os.ReadFile(file); err != nil {
@@ -243,11 +248,13 @@ func Run(lg *slog.Logger, options *Options) (result map[string]string, err error
 		repository    *git.Repository                                             // the object for this repo
 		semvers       []*semver.Semver                                            // all valid semver tags in the repo
 		use           *semver.Semver                                              // the semver to use for the prerelease / release
-		defaultBranch *plumbing.Reference                                         // git ref for the default branch
+		lastRelease   *semver.Semver                                              // the last release or default branch
+		baseRef       *plumbing.Reference                                         // git ref for previous ref (main / or last release)
 		currentCommit *plumbing.Reference                                         // git sha / ref for where the git repo currently is
 		createdTag    *plumbing.Reference                                         // the new semver tag thats been created
 		newCommits    []*object.Commit                                            // all commits that exist in the ref
 		bump          semver.Increment    = semver.Increment(options.DefaultBump) // default increment
+		basePoint     string              = ""                                    // either ref of last release or the default branch
 		token         string              = os.Getenv("GH_TOKEN")                 // github auth token for pushing to the remote
 	)
 	result = map[string]string{}
@@ -267,9 +274,17 @@ func Run(lg *slog.Logger, options *Options) (result map[string]string, err error
 	if err != nil {
 		return
 	}
+	// get the last release for the comparison point
+	lastRelease = semver.GetLastRelease(lg, semvers)
+	if lastRelease != nil {
+		basePoint = lastRelease.Stringy(true)
+	} else {
+		basePoint = options.DefaultBranch
+	}
+
 	// get the default branch info
-	if defaultBranch, err = commits.FindReference(lg, repository, options.DefaultBranch); err != nil {
-		lg.Error("error getting git reference for default branch", "err", err.Error(), "default_branch", options.DefaultBranch)
+	if baseRef, err = commits.FindReference(lg, repository, basePoint); err != nil {
+		lg.Error("error getting git reference for previous comparison point", "err", err.Error(), "basePoint", basePoint)
 		return
 	}
 	// get info on the current commit
@@ -277,23 +292,21 @@ func Run(lg *slog.Logger, options *Options) (result map[string]string, err error
 		lg.Error("error getting git reference for branch", "err", err.Error(), "branch", options.BranchName)
 		return
 	}
-	// find new commits that are in the current tree, but not
-	if newCommits, err = commits.DiffBetween(lg, repository, defaultBranch.Hash(), currentCommit.Hash()); err != nil {
-		lg.Error("error commits between references", "err", err.Error(), "base", defaultBranch.Hash().String(), "head", currentCommit.Hash().String())
+	// find new commits between the baseRef (main / last release) and the current commit
+	if newCommits, err = commits.DiffBetween(lg, repository, baseRef.Hash(), currentCommit.Hash()); err != nil {
+		lg.Error("error commits between references", "err", err.Error(), "base", baseRef.Hash().String(), "head", currentCommit.Hash().String())
 		return
 	}
 
-	lg.Warn("event file", "file", options.EventContentFile)
-	// add content to the commit list
-	if options.EventContentFile != "" {
-		extra := getContentFromEventFile(lg, options.EventContentFile)
+	// add content to the commit list from the event file
+	if extra := getContentFromEventFile(lg, options.EventContentFile); len(extra) > 0 {
 		newCommits = append(newCommits, &object.Commit{Hash: plumbing.ZeroHash, Message: extra})
 	}
 
-	lg.Warn("found commits", "len", len(newCommits))
+	lg.Info("details", "commits", len(newCommits), "event-file", options.EventContentFile)
 
 	for _, c := range newCommits {
-		fmt.Printf("==>\n%s\n<==\n", c.Message)
+		fmt.Printf("> commit ==>\n%s\n<==\n", c.Message)
 	}
 
 	// look for bump in the commits,

--- a/action/cmd/semver/main_test.go
+++ b/action/cmd/semver/main_test.go
@@ -63,6 +63,7 @@ func TestMainPush(t *testing.T) {
 				{Message: "foobar", Branch: "master"},
 				{Message: "just one #minor", Branch: "master"},
 				{Message: "this ones #major", Branch: "master"},
+				{Message: "so is this one #major", Branch: "master"},
 			},
 		},
 	}

--- a/action/cmd/semver/main_test.go
+++ b/action/cmd/semver/main_test.go
@@ -28,8 +28,98 @@ type tSemTest struct {
 	ShouldError   bool
 }
 
-// Test generating various semvers
-func TestMain(t *testing.T) {
+// Tests that align to what happens on push - so commits on the default branch
+// after a release that should trigger a semver bump
+func TestMainPush(t *testing.T) {
+	var lg = logger.New("ERROR", "TEXT")
+	var tests = []*tSemTest{
+		// make a commit with #minor commit on the top of master (default branch)
+		{
+			ExpectedTag:   "v1.1.0",
+			ExpectedBump:  string(semver.MINOR),
+			ShouldError:   false,
+			CreateRelease: true,
+			Input: &Options{
+				Prerelease:    false,
+				DefaultBranch: "master",
+				BranchName:    "master",
+			},
+			Commits: []*tSemTestCommit{
+				{Message: "just one #minor", Branch: "master"},
+			},
+		},
+		// make commits with #major in there on the top of master (default branch)
+		{
+			ExpectedTag:   "v2.0.0",
+			ExpectedBump:  string(semver.MAJOR),
+			ShouldError:   false,
+			CreateRelease: true,
+			Input: &Options{
+				Prerelease:    false,
+				DefaultBranch: "master",
+				BranchName:    "master",
+			},
+			Commits: []*tSemTestCommit{
+				{Message: "foobar", Branch: "master"},
+				{Message: "just one #minor", Branch: "master"},
+				{Message: "this ones #major", Branch: "master"},
+			},
+		},
+	}
+
+	// var dir = "./test-repo"
+	// os.RemoveAll(dir)
+	// os.MkdirAll(dir, os.ModePerm)
+	// r, defBranch := randomRepository(dir, true)
+	// w, _ := r.Worktree()
+
+	for i, test := range tests {
+		var (
+			dir          = t.TempDir()
+			r, defBranch = randomRepository(dir, test.CreateRelease)
+			w, _         = r.Worktree()
+		)
+
+		err := testSetup(test, r, w, defBranch)
+		if err != nil {
+			t.Error(err)
+			t.FailNow()
+		}
+		// setup the options to run
+		opts := newRunOptions(test.Input)
+		if opts.RepositoryDirectory == "" {
+			opts.RepositoryDirectory = dir
+		}
+		if opts.DefaultBranch == "" {
+			opts.DefaultBranch = defBranch.Name().Short()
+		}
+		// now run the command and compare
+		res, err := Run(lg, opts)
+		// check error states
+		if !test.ShouldError && err != nil {
+			t.Errorf("[%d] unexpected error: %s", i, err.Error())
+		} else if test.ShouldError && err == nil {
+			t.Errorf("[%d] expected an error, but did not get one", i)
+		}
+		// check values
+		if res["tag"] != test.ExpectedTag {
+			t.Errorf("[%d] expected tag [%s] actual [%s]", i, test.ExpectedTag, res["tag"])
+			debug(res)
+		}
+		if res["bump"] != test.ExpectedBump {
+			t.Errorf("[%d] expected bump [%s] actual [%s]", i, test.ExpectedBump, res["bump"])
+			debug(res)
+		}
+		// debug(res)
+
+	}
+
+	// t.FailNow()
+
+}
+
+// Test generating various semvers in setup that looks like pull requests
+func TestMainPR(t *testing.T) {
 
 	var lg = logger.New("ERROR", "TEXT")
 	var tests = []*tSemTest{
@@ -91,7 +181,6 @@ func TestMain(t *testing.T) {
 				{Message: "just one commit"},
 			},
 		},
-
 		// test a prerelease tag that clashes with a similar branch and
 		// tag that triggers a minor
 		{
@@ -234,7 +323,6 @@ func TestMain(t *testing.T) {
 				},
 			},
 		},
-
 		// test returning the last semver release tag as there
 		// are no new commits and default bump is set to 'none'
 		{
@@ -249,7 +337,6 @@ func TestMain(t *testing.T) {
 			},
 			Commits: []*tSemTestCommit{},
 		},
-
 		// test a series of commits on a branch that should generate
 		// a prerelease tag
 		{
@@ -354,6 +441,7 @@ func TestMain(t *testing.T) {
 
 }
 
+// testSetup generates some base commits / branches / tags to use in test scenarios
 func testSetup(test *tSemTest, r *git.Repository, w *git.Worktree, defBranch *plumbing.Reference) (err error) {
 	var author = &object.Signature{Name: "go test", Email: "test@example.com"}
 	// now create the test commits

--- a/action/internal/semver/semver.go
+++ b/action/internal/semver/semver.go
@@ -378,6 +378,21 @@ func atoi(s string) (i int) {
 	return
 }
 
+// GetLastRelease returns the last release it can find, or nil
+func GetLastRelease(lg *slog.Logger, existing []*Semver) (last *Semver) {
+	var releases []*Semver
+
+	lg = lg.With("operation", "GetLastRelease")
+	lg.Debug("sorting releases ... ")
+	// get releases only and sort them descending order so the lastest is on the top
+	releases = Sort(lg, GetReleases(existing), SORT_DESC, false)
+	if len(releases) >= 0 {
+		last = releases[0]
+	}
+
+	return
+}
+
 // Release runs over the existing Semvers, finds that largest (naturally sorted) version
 // and increments that value by bump.
 //
@@ -386,20 +401,13 @@ func atoi(s string) (i int) {
 //
 // If no releases are found, `0.0.0` is used instead.
 func Release(lg *slog.Logger, existing []*Semver, bump Increment) (next *Semver) {
-	var (
-		last     *Semver
-		releases []*Semver
-	)
+	var last *Semver
 	lg = lg.With("operation", "Release", "bump", string(bump))
-	lg.Debug("sorting releases ... ")
-	// get releases only and sort them descending order
-	releases = Sort(lg, GetReleases(existing), SORT_DESC, false)
-	// If there are no releases, then use 0 as base
-	// Otherwise, use the last release
-	if len(releases) == 0 {
+
+	last = GetLastRelease(lg, existing)
+
+	if last == nil {
 		last = FromString("0.0.0")
-	} else {
-		last = releases[0]
 	}
 
 	lg.Debug("last release ... ", "last", last.Stringy(true))

--- a/action/internal/semver/semver.go
+++ b/action/internal/semver/semver.go
@@ -405,7 +405,6 @@ func Release(lg *slog.Logger, existing []*Semver, bump Increment) (next *Semver)
 	lg = lg.With("operation", "Release", "bump", string(bump))
 
 	last = GetLastRelease(lg, existing)
-
 	if last == nil {
 		last = FromString("0.0.0")
 	}

--- a/action/internal/semver/semver.go
+++ b/action/internal/semver/semver.go
@@ -386,7 +386,7 @@ func GetLastRelease(lg *slog.Logger, existing []*Semver) (last *Semver) {
 	lg.Debug("sorting releases ... ")
 	// get releases only and sort them descending order so the lastest is on the top
 	releases = Sort(lg, GetReleases(existing), SORT_DESC, false)
-	if len(releases) >= 0 {
+	if len(releases) > 0 {
 		last = releases[0]
 	}
 


### PR DESCRIPTION
From the [last merge workflow](https://github.com/ministryofjustice/opg-github-actions/actions/runs/16798507933) can see that the issue is the states its comparing .. its looking for commits between `main...main` - so finds nothing.

This changes that, so instead of using the default branch as the comparison point it uses the last release. If there is no last release then it will use the default branch. Also added handling for the `push` event file, so it should also find commits in there.

We don't remove duplicate commits, but the semver bump is not additive, so even if it finds 3 majors, it will only bump it once.