### PR TITLE
Always output the cleaned branch name

### DIFF
--- a/action/cmd/semver/main_test.go
+++ b/action/cmd/semver/main_test.go
@@ -20,12 +20,13 @@ type tSemTestCommit struct {
 }
 
 type tSemTest struct {
-	Commits       []*tSemTestCommit
-	ExpectedTag   string
-	ExpectedBump  string
-	Input         *Options
-	CreateRelease bool
-	ShouldError   bool
+	Commits        []*tSemTestCommit
+	ExpectedTag    string
+	ExpectedBump   string
+	ExpectedBranch string
+	Input          *Options
+	CreateRelease  bool
+	ShouldError    bool
 }
 
 // Tests that align to what happens on push - so commits on the default branch
@@ -35,10 +36,11 @@ func TestMainPush(t *testing.T) {
 	var tests = []*tSemTest{
 		// make a commit with #minor commit on the top of master (default branch)
 		{
-			ExpectedTag:   "v1.1.0",
-			ExpectedBump:  string(semver.MINOR),
-			ShouldError:   false,
-			CreateRelease: true,
+			ExpectedTag:    "v1.1.0",
+			ExpectedBump:   string(semver.MINOR),
+			ExpectedBranch: "master",
+			ShouldError:    false,
+			CreateRelease:  true,
 			Input: &Options{
 				Prerelease:    false,
 				DefaultBranch: "master",
@@ -109,6 +111,11 @@ func TestMainPush(t *testing.T) {
 		}
 		if res["bump"] != test.ExpectedBump {
 			t.Errorf("[%d] expected bump [%s] actual [%s]", i, test.ExpectedBump, res["bump"])
+			debug(res)
+		}
+
+		if test.ExpectedBranch != "" && res["branch"] != test.ExpectedBranch {
+			t.Errorf("[%d] expected branch [%s] actual [%s]", i, test.ExpectedBranch, res["branch"])
 			debug(res)
 		}
 		// debug(res)
@@ -341,10 +348,11 @@ func TestMainPR(t *testing.T) {
 		// test a series of commits on a branch that should generate
 		// a prerelease tag
 		{
-			ExpectedTag:   "v1.1.0-testbrancha.1",
-			ExpectedBump:  string(semver.MINOR),
-			ShouldError:   false,
-			CreateRelease: true,
+			ExpectedTag:    "v1.1.0-testbrancha.1",
+			ExpectedBump:   string(semver.MINOR),
+			ExpectedBranch: "testbrancha",
+			ShouldError:    false,
+			CreateRelease:  true,
 			Input: &Options{
 				Prerelease: true,
 				BranchName: "test-branch-a",
@@ -364,10 +372,11 @@ func TestMainPR(t *testing.T) {
 		// test a series commits with multi lines and special chars
 		// that should create a minor
 		{
-			ExpectedTag:   "v2.0.0-testbranchutf.1",
-			ExpectedBump:  string(semver.MAJOR),
-			ShouldError:   false,
-			CreateRelease: true,
+			ExpectedTag:    "v2.0.0-testbranchutf.1",
+			ExpectedBump:   string(semver.MAJOR),
+			ExpectedBranch: "testbranch-utf",
+			ShouldError:    false,
+			CreateRelease:  true,
 			Input: &Options{
 				PrereleaseSuffixLength: 15,
 				Prerelease:             true,
@@ -434,6 +443,11 @@ func TestMainPR(t *testing.T) {
 			t.Errorf("[%d] expected bump [%s] actual [%s]", i, test.ExpectedBump, res["bump"])
 			debug(res)
 		}
+		if test.ExpectedBranch != "" && res["branch"] != test.ExpectedBranch {
+			t.Errorf("[%d] expected branch [%s] actual [%s]", i, test.ExpectedBranch, res["branch"])
+			debug(res)
+		}
+
 		// debug(res)
 
 	}

--- a/actions/semver/README.md
+++ b/actions/semver/README.md
@@ -70,7 +70,7 @@ Common inputs:
 - `release_artifact` (default: "")
 
 Rarely used inputs:
-- `prelease_suffix_length` (default: "12")
+- `prelease_suffix_length` (default: "14")
 - `branch_name`
 - `without_prefix` (default: "false")
 - `github_token`

--- a/actions/semver/README.md
+++ b/actions/semver/README.md
@@ -80,6 +80,7 @@ Rarely used inputs:
 Outputs:
 - **`tag`**
 - `hash`
+- `branch`
 - `created`
 - `bump`
 - `test`
@@ -123,6 +124,9 @@ Contains the tag that has been created.
 
 #### `hash`
 The git hash / sha that the tag was created at.
+
+#### `branch`
+The cleaned and truncated branch name that was used for this tag. Is always set.
 
 #### `created`
 A boolean shoing if the tag was actually created - helpful for `test` and `none` increment usages.

--- a/actions/semver/action.yml
+++ b/actions/semver/action.yml
@@ -53,6 +53,10 @@ outputs:
     description: "Git sha / reference where the tag was created / found."
     value: ${{ steps.cmd.outputs.hash }}
 
+  branch:
+    description: "The safe, truncated branch name used in the semver creation. Always returned."
+    value: ${{ steps.cmd.outputs.branch }}
+
   created:
     description: "Boolean to say if the tag was created or not."
     value: ${{ steps.cmd.outputs.created }}

--- a/actions/semver/action.yml
+++ b/actions/semver/action.yml
@@ -173,6 +173,7 @@ runs:
         # outputs of the command
         tag: ${{ steps.cmd.outputs.tag }}
         hash: ${{ steps.cmd.outputs.hash }}
+        branch_output: ${{ steps.cmd.outputs.branch }}
         test: ${{ steps.cmd.outputs.test }}
         created: ${{ steps.cmd.outputs.created }}
         bump: ${{ steps.cmd.outputs.bump }}
@@ -193,6 +194,7 @@ runs:
         echo "| --- | --- |"  >> $GITHUB_STEP_SUMMARY
         echo "| tag | ${{ env.tag }} |" >> $GITHUB_STEP_SUMMARY
         echo "| hash | ${{ env.hash }} |" >> $GITHUB_STEP_SUMMARY
+        echo "| branch | ${{ env.branch_output }} |" >> $GITHUB_STEP_SUMMARY
         echo "| created | ${{ env.created }} |" >> $GITHUB_STEP_SUMMARY
         echo "| test | ${{ env.test }} |" >> $GITHUB_STEP_SUMMARY
         echo "| bump | ${{ env.bump }} |" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Some workflows use the branch name output from the semver tag instead of working out clean name again, so adding that as an output to the action