### PR TITLE
Add a retry loop !minor

### DIFF
--- a/action/cmd/semver/main.go
+++ b/action/cmd/semver/main.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"fmt"
 	"log/slog"
+	"math/rand/v2"
 	"opg-github-actions/action/internal/commits"
 	"opg-github-actions/action/internal/logger"
 	"opg-github-actions/action/internal/repo"
@@ -13,6 +14,8 @@ import (
 	"opg-github-actions/action/internal/strs"
 	"opg-github-actions/action/internal/tags"
 	"os"
+	"strings"
+	"time"
 
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
@@ -140,9 +143,9 @@ func createAndPushTag(
 
 	var (
 		remotes              []*git.Remote
+		tagName              string = use.String()
 		errFailedToCreateTag string = "error: failed to create tag [%s]"
 		errFailedToPush      string = "error: failed to push tags to remote [tag: %s]"
-		tagName              string = use.String()
 		auth                        = &http.BasicAuth{
 			Username: "opg-github-actions",
 			Password: token,
@@ -275,13 +278,16 @@ func getContentFromEventFile(lg *slog.Logger, file string) (content string) {
 //   - Finds all commits that exist in the currently checked out location, but not in default branch tree - these are the new ones
 //     -- Merges the extra-content argument into this data (pull request details)
 //   - Looks at the new commits for #major|minor|patch content to determine the semver increment
-//   - Works out the new new tag
-//   - Creates and pushes the tag
+//   - Retry loop
+//     -- Works out the new new tag
+//     -- Creates and pushes the tag
 //   - Outputs data
 //
 // If you have enabled test mode (via `--test`) the tag will not be created or pushed.
 // If there are no new commits, or no commits with #major|minor|patch then the default increment (`--bump`)
 // will be used.
+//
+// Will try to create tag multiple times
 func Run(lg *slog.Logger, options *Options) (result map[string]string, err error) {
 	var (
 		repository    *git.Repository                                             // the object for this repo
@@ -295,7 +301,9 @@ func Run(lg *slog.Logger, options *Options) (result map[string]string, err error
 		bump          semver.Increment    = semver.Increment(options.DefaultBump) // default increment
 		basePoint     string              = ""                                    // either ref of last release or the default branch
 		token         string              = os.Getenv("GH_TOKEN")                 // github auth token for pushing to the remote
-		bumpCommit    string              = ""                                    // commit message the cump wasa found within
+		bumpCommit    string              = ""                                    // commit message the bump was found within
+		errTagExists  string              = "reference already exists"            // in cases where tag exists, look for this error string
+		maxRetries    int                 = 20                                    // max retries
 	)
 	result = map[string]string{}
 
@@ -361,13 +369,31 @@ func Run(lg *slog.Logger, options *Options) (result map[string]string, err error
 	if len(newCommits) > 0 && foundBump != "" {
 		bump = foundBump
 	}
+	// retry loop
+	// In some places the semver action may run on the same repository at almost the same time
+	// (such as mono repos with multiple projects)
+	// In those cases we loop multiple times to try to create a new tag for each thing
+	for attempt := 0; attempt < maxRetries; attempt++ {
+		var n = rand.IntN(5)
+		repo.Fetch(lg, repository)
+		// find the semver and set the git ref to the current place
+		use = getSemverToUse(lg, semvers, bump, options)
+		use.GitRef = currentCommit
+		lg.Info("generated semver ... ", "use", use, "attempt", attempt)
+		// create and try to push tags
+		createdTag, err = createAndPushTag(lg, repository, use, bump, token, options)
 
-	use = getSemverToUse(lg, semvers, bump, options)
-	lg.Info("got semver ... ", "use", use)
-	// set the git ref to the current place
-	use.GitRef = currentCommit
-	// create and try to push tags
-	createdTag, err = createAndPushTag(lg, repository, use, bump, token, options)
+		// if there is an error and its not about existing tags, then exit
+		if err != nil && !strings.Contains(err.Error(), errTagExists) {
+			return
+		}
+		// if there is no error, then break the loop
+		if err == nil {
+			break
+		}
+		lg.Info("need to retry tag creation; sleeping ... ", "seconds", n)
+		time.Sleep(time.Duration(n) * time.Second)
+	}
 
 	result = map[string]string{
 		"tag":     use.String(),

--- a/action/cmd/semver/main.go
+++ b/action/cmd/semver/main.go
@@ -163,7 +163,7 @@ func createAndPushTag(
 
 	lg.Debug("creating tag ... ")
 	// try to create the tag locally
-	createdTag, err = tags.Create(repository, tagName, use.GitRef.Hash())
+	createdTag, err = tags.Create(lg, repository, tagName, use.GitRef.Hash())
 	if err != nil {
 		tagErr := fmt.Errorf(errFailedToCreateTag, tagName)
 		err = errors.Join(tagErr, err)
@@ -174,11 +174,11 @@ func createAndPushTag(
 	// if we have some remotes, push
 	if len(remotes) > 0 {
 		lg.Debug("pushing tags ... ")
-		err = tags.Push(repository, auth)
+		err = tags.Push(lg, repository, auth)
 		if err != nil {
 			tagErr := fmt.Errorf(errFailedToPush, tagName)
 			err = errors.Join(tagErr, err)
-			lg.Error("failed to push tag ... ", "err", err.Error())
+			lg.Error("error pushing tag ... ", "err", err.Error())
 			return
 		}
 	}

--- a/action/internal/repo/repo.go
+++ b/action/internal/repo/repo.go
@@ -91,8 +91,8 @@ func Init(localDirectory string) (r *git.Repository, err error) {
 // fetch might not be needed - added for when
 // repo is shallow and doesnt have all the refs
 // when then causes a failure on branch look up
-func Fetch(lg *slog.Logger, r *git.Repository) (err error) {
-	slog.Info("fetching remotes ...")
+func Fetch(lg *slog.Logger, r *git.Repository, auth *http.BasicAuth) (err error) {
+	lg.Info("fetching updates from remotes ...")
 
 	remotes, err := r.Remotes()
 	specs := []config.RefSpec{
@@ -104,18 +104,18 @@ func Fetch(lg *slog.Logger, r *git.Repository) (err error) {
 	for _, remote := range remotes {
 		// fetch branches and tags for this remote
 		name := remote.Config().Name
-		lg.Debug("fetching remote data for: " + name)
+		lg.Debug("fetching data for remote ", "remote", name)
 
 		err = r.Fetch(&git.FetchOptions{
 			RemoteName: name,
 			RefSpecs:   specs,
+			Auth:       auth,
 		})
 
 		if err != nil && err != git.NoErrAlreadyUpToDate {
-			lg.Error("Error with fetch")
-			lg.Error(err.Error())
+			lg.Error("error with fetching repository", "err", err.Error())
 		} else if err != nil {
-			lg.Warn(err.Error())
+			lg.Warn("repository up to date", "warning", err.Error())
 			err = nil
 		}
 	}

--- a/action/internal/repo/repo.go
+++ b/action/internal/repo/repo.go
@@ -1,6 +1,7 @@
 package repo
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -92,6 +93,8 @@ func Init(localDirectory string) (r *git.Repository, err error) {
 // repo is shallow and doesnt have all the refs
 // when then causes a failure on branch look up
 func Fetch(lg *slog.Logger, r *git.Repository, auth *http.BasicAuth) (err error) {
+	lg = lg.With("operation", "Fetch")
+
 	lg.Info("fetching updates from remotes ...")
 
 	remotes, err := r.Remotes()
@@ -111,13 +114,12 @@ func Fetch(lg *slog.Logger, r *git.Repository, auth *http.BasicAuth) (err error)
 			RefSpecs:   specs,
 			Auth:       auth,
 		})
-
-		if err != nil && err != git.NoErrAlreadyUpToDate {
-			lg.Error("error with fetching repository", "err", err.Error())
-		} else if err != nil {
+		// this isnt an error, so handle and ignore it
+		if errors.Is(err, git.NoErrAlreadyUpToDate) {
 			lg.Warn("repository up to date", "warning", err.Error())
 			err = nil
 		}
+
 	}
 	return
 }

--- a/action/internal/tags/tags_test.go
+++ b/action/internal/tags/tags_test.go
@@ -179,7 +179,7 @@ func TestTagCreationSimple(t *testing.T) {
 	repo, head := randomRepository(dir)
 	tags1, _ := All(lg, repo)
 
-	Create(repo, tagName, head.Hash())
+	Create(lg, repo, tagName, head.Hash())
 
 	tags2, _ := All(lg, repo)
 

--- a/actions/release/README.md
+++ b/actions/release/README.md
@@ -2,6 +2,8 @@
 
 Will create a new release using `gh` cli tool based on the tag value passed along.
 
+Limited to one release per tag.
+
 
 ## Usage
 
@@ -58,3 +60,8 @@ Pattern or file path for artifacts you want to attach to this release, such as b
 
 #### `release_notes_flag` (default: "--notes-from-tag")
 When creating a release with the `gh` cli tool there are two two methods for generating notes, this lets you swap between them.
+
+### Outputs
+
+#### `url`
+Link to the url of the release for the tag passed.

--- a/actions/release/action.yml
+++ b/actions/release/action.yml
@@ -44,9 +44,9 @@ runs:
         tag: ${{ inputs.tag }}
         fields: "name,tagName,isDraft,isPrerelease"
         prerelease_select: ${{ inputs.prerelease == 'true' && '| select(.isPrerelease==true)' || '' }}
-        tagname_select: '| select(.tagName=="${{ env.tag }}")'
       run: |
-        list=$(gh release list --json="${{ env.fields }}" --jq='.[] ${{ env.tagname_select }} ${{ env.prerelease_select }} | .tagName')
+        echo "Looking for release with tag name: ${{ env.tag }}"
+        list=$(gh release list --json="${{ env.fields }}" --jq='.[] | select(.tagName=="${{ env.tag }}") ${{ env.prerelease_select }} | .tagName')
         if [[ "$list" == "${{ env.tag }}" ]];
           echo "RELEASE_EXISTS=true" >> $GITHUB_OUTPUT
         fi

--- a/actions/release/action.yml
+++ b/actions/release/action.yml
@@ -45,7 +45,8 @@ runs:
         prerelease_select: ${{ inputs.prerelease == 'true' && '| select(.isPrerelease==true)' || '' }}
       run: |
         echo "Looking for release with tag name: ${{ env.tag }}"
-        list=$(gh release list --json=""name,tagName,isDraft,isPrerelease" --jq='.[] | select(.tagName=="${{ env.tag }}") ${{ env.prerelease_select }} | .tagName')
+
+        list=$(gh release list --json='name,tagName,isDraft,isPrerelease' --jq='.[] | select(.tagName=="${{ env.tag }}") ${{ env.prerelease_select }} | .tagName')
         if [[ "$list" == "${{ env.tag }}" ]];
           echo "RELEASE_EXISTS=true" >> $GITHUB_OUTPUT
         fi

--- a/actions/release/action.yml
+++ b/actions/release/action.yml
@@ -38,6 +38,9 @@ runs:
       id: find_release
       shell: bash
       env:
+        # token auth
+        GH_TOKEN: ${{ inputs.github_token != '' && inputs.github_token || github.token }}
+        # setup
         tag: ${{ inputs.tag }}
         fields: "name,tagName,isDraft,isPrerelease"
         prerelease_select: ${{ inputs.prerelease == 'true' && '| select(.isPrerelease==true)' || '' }}
@@ -59,10 +62,10 @@ runs:
       shell: bash
       if: steps.find_release.outputs.RELEASE_EXISTS == 'true'
       env:
-        # release exists
-        exists: ${{ steps.find_release.outputs.RELEASE_EXISTS }}
         # token auth
         GH_TOKEN: ${{ inputs.github_token != '' && inputs.github_token || github.token }}
+        # release exists
+        exists: ${{ steps.find_release.outputs.RELEASE_EXISTS }}
         # prerelease for the release aligns with the prelreease flag for the tag generation
         prerelease: ${{ inputs.prerelease == 'true' && '--prerelease' || '' }}
         # latest is only true when this is not a prerelease; input can overwrite this

--- a/actions/release/action.yml
+++ b/actions/release/action.yml
@@ -47,20 +47,22 @@ runs:
         echo "Looking for release with tag name: ${{ env.tag }}"
 
         list=$(gh release list --json='name,tagName,isDraft,isPrerelease' --jq='.[] | select(.tagName=="${{ env.tag }}") ${{ env.prerelease_select }} | .tagName')
+        echo "found=${list}"
+
         if [[ "$list" == "${{ env.tag }}" ]]; then
           echo "RELEASE_EXISTS=true" >> $GITHUB_OUTPUT
         fi
 
     - name: "Release already exists, skipping [tag: ${{ inputs.tag }} pre: ${{ inputs.prerelease }}]"
       shell: bash
-      if: steps.find_release.outputs.RELEASE_EXISTS != 'true'
+      if: steps.find_release.outputs.RELEASE_EXISTS == 'true'
       run: |
         echo "release already exists for this tag "
 
     - name: "Create a release for [tag: ${{ inputs.tag }} pre: ${{ inputs.prerelease }}]"
       id: create_release
       shell: bash
-      if: steps.find_release.outputs.RELEASE_EXISTS == 'true'
+      if: steps.find_release.outputs.RELEASE_EXISTS != 'true'
       env:
         # token auth
         GH_TOKEN: ${{ inputs.github_token != '' && inputs.github_token || github.token }}

--- a/actions/release/action.yml
+++ b/actions/release/action.yml
@@ -42,11 +42,10 @@ runs:
         GH_TOKEN: ${{ inputs.github_token != '' && inputs.github_token || github.token }}
         # setup
         tag: ${{ inputs.tag }}
-        fields: "name,tagName,isDraft,isPrerelease"
         prerelease_select: ${{ inputs.prerelease == 'true' && '| select(.isPrerelease==true)' || '' }}
       run: |
         echo "Looking for release with tag name: ${{ env.tag }}"
-        list=$(gh release list --json="${{ env.fields }}" --jq='.[] | select(.tagName=="${{ env.tag }}") ${{ env.prerelease_select }} | .tagName')
+        list=$(gh release list --json=""name,tagName,isDraft,isPrerelease" --jq='.[] | select(.tagName=="${{ env.tag }}") ${{ env.prerelease_select }} | .tagName')
         if [[ "$list" == "${{ env.tag }}" ]];
           echo "RELEASE_EXISTS=true" >> $GITHUB_OUTPUT
         fi

--- a/actions/release/action.yml
+++ b/actions/release/action.yml
@@ -47,7 +47,7 @@ runs:
         echo "Looking for release with tag name: ${{ env.tag }}"
 
         list=$(gh release list --json='name,tagName,isDraft,isPrerelease' --jq='.[] | select(.tagName=="${{ env.tag }}") ${{ env.prerelease_select }} | .tagName')
-        if [[ "$list" == "${{ env.tag }}" ]];
+        if [[ "$list" == "${{ env.tag }}" ]]; then
           echo "RELEASE_EXISTS=true" >> $GITHUB_OUTPUT
         fi
 

--- a/actions/release/action.yml
+++ b/actions/release/action.yml
@@ -28,6 +28,10 @@ inputs:
     description: "Flag to use for note generation - can be `--notes-from-tag` or `--generate-notes`"
     default: "--notes-from-tag"
 
+outputs:
+  url:
+    description: "Link to the release"
+    value: "${{ steps.release_url.outputs.URL }}"
 
 runs:
   using: composite
@@ -49,7 +53,7 @@ runs:
         list=$(gh release list --json='name,tagName,isDraft,isPrerelease' --jq='.[] | select(.tagName=="${{ env.tag }}") ${{ env.prerelease_select }} | .tagName')
         echo "found=${list}"
 
-        if [[ "$list" == "${{ env.tag }}" ]]; then
+        if [[ "${list}" == "${{ env.tag }}" ]]; then
           echo "RELEASE_EXISTS=true" >> $GITHUB_OUTPUT
         fi
 
@@ -57,10 +61,9 @@ runs:
       shell: bash
       if: steps.find_release.outputs.RELEASE_EXISTS == 'true'
       run: |
-        echo "release already exists for this tag "
+        echo "release already exists for this tag"
 
     - name: "Create a release for [tag: ${{ inputs.tag }} pre: ${{ inputs.prerelease }}]"
-      id: create_release
       shell: bash
       if: steps.find_release.outputs.RELEASE_EXISTS != 'true'
       env:
@@ -83,3 +86,21 @@ runs:
         gh release create ${{ env.tag }} ${{ env.artifacts }} \
           ${{ env.prerelease }} ${{ env.latest }} ${{ env.notes }} --verify-tag \
           -t ${{ env.tag }}
+
+    # output details about release to github
+    - name: "Fetching link to release [tag: ${{ inputs.tag }} pre: ${{ inputs.prerelease }} ]"
+      id: release_url
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github_token != '' && inputs.github_token || github.token }}
+        tag: ${{ inputs.tag }}
+      run: |
+        echo "Looking for release with tag name: ${{ env.tag }}"
+        link=$(gh release view ${{ env.tag }} --json="url" --jq=".url")
+
+        if [[ "${link}" != "" ]]; then
+          echo "URL=${link}" >> $GITHUB_OUTPUT
+          echo "| Variable | Value |" >> $GITHUB_STEP_SUMMARY
+          echo "| --- | --- |"  >> $GITHUB_STEP_SUMMARY
+          echo "| release_url | ${link} |"  >> $GITHUB_STEP_SUMMARY
+        fi

--- a/actions/release/action.yml
+++ b/actions/release/action.yml
@@ -31,12 +31,36 @@ inputs:
 
 runs:
   using: composite
+
   steps:
     ####### RUN COMMAND
-    - name: "Create a release for [tag: ${{ inputs.tag }} pre: ${{ inputs.prerelease}} ]"
+    - name: "Looking for existing release for tag [tag: ${{ inputs.tag }} pre: ${{ inputs.prerelease }} ]"
+      id: find_release
       shell: bash
-      id: create_release
       env:
+        tag: ${{ inputs.tag }}
+        fields: "name,tagName,isDraft,isPrerelease"
+        prerelease_select: ${{ inputs.prerelease == 'true' && '| select(.isPrerelease==true)' || '' }}
+        tagname_select: '| select(.tagName=="${{ env.tag }}")'
+      run: |
+        list=$(gh release list --json="${{ env.fields }}" --jq='.[] ${{ env.tagname_select }} ${{ env.prerelease_select }} | .tagName')
+        if [[ "$list" == "${{ env.tag }}" ]];
+          echo "RELEASE_EXISTS=true" >> $GITHUB_OUTPUT
+        fi
+
+    - name: "Release already exists, skipping [tag: ${{ inputs.tag }} pre: ${{ inputs.prerelease }}]"
+      shell: bash
+      if: steps.find_release.outputs.RELEASE_EXISTS != 'true'
+      run: |
+        echo "release already exists for this tag "
+
+    - name: "Create a release for [tag: ${{ inputs.tag }} pre: ${{ inputs.prerelease }}]"
+      id: create_release
+      shell: bash
+      if: steps.find_release.outputs.RELEASE_EXISTS == 'true'
+      env:
+        # release exists
+        exists: ${{ steps.find_release.outputs.RELEASE_EXISTS }}
         # token auth
         GH_TOKEN: ${{ inputs.github_token != '' && inputs.github_token || github.token }}
         # prerelease for the release aligns with the prelreease flag for the tag generation


### PR DESCRIPTION
this action may be used in concurrent locations, so needs to handle clashing tags being created, so add a retry loop with a sleep.

Updated the release action to handle existing releases

Found via org-infra running many at once and can see the action results there as well - https://github.com/ministryofjustice/opg-org-infra/pull/3362