### PR TITLE
UML-4385 - Fix detect-changes action on push events

### DIFF
--- a/actions/detect-changes/action.yml
+++ b/actions/detect-changes/action.yml
@@ -37,7 +37,8 @@ runs:
             RANGE="origin/${GITHUB_BASE_REF}...HEAD"
             ;;
           push)
-            RANGE="${GITHUB_EVENT_BEFORE} ${GITHUB_SHA}"
+            BEFORE=$(jq -r '.before' "$GITHUB_EVENT_PATH")
+            RANGE="${BEFORE} ${GITHUB_SHA}"
             ;;
           merge_group)
             BASE=$(jq -r '.merge_group.base_sha' "$GITHUB_EVENT_PATH")


### PR DESCRIPTION
GITHUB_EVENT_BEFORE isn't a default gh action env variable, so using the same approach as merge group 